### PR TITLE
Repair Autovacuum confguration

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -48,6 +48,10 @@ chown_pgdata:
       wal_log_hints: false
       max_wal_senders: 5 # NOTE: Since postgresql-10, the default is 10
       log_autovacuum_min_duration: '500ms'
+      autovacuum_vacuum_cost_delay: 20ms
+      autovacuum_vacuum_cost_limit: -1
+      autovacuum_vacuum_threshold: 50
+      autovacuum_vacuum_scale_factor: 0.2
     - context:
       # Override defaults from pillar configuration
 {% for key in [

--- a/pillar.example
+++ b/pillar.example
@@ -45,6 +45,10 @@ postgresql:
     shared_buffers: 128MB
     maintenance_work_mem: 64MB
     effective_cache_size: 4GB
+    autovacuum_vacuum_cost_delay: 20ms
+    autovacuum_vacuum_cost_limit: -1
+    autovacuum_vacuum_threshold: 50
+    autovacuum_vacuum_scale_factor: 0.2
 
   # These users will be created and added to pg_hba.conf
   # NOTE: If you create multiple users with access to the same database, the first user listed


### PR DESCRIPTION
Your changes regarding the autovacuum configuration breaks the state in case it is not defined in the pillar file. I suggest to either set defaults or change the example pillar (or both).